### PR TITLE
Update version and log path integration across modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent",
-  "version": "0.1.3",
+  "version": "0.1.7",
   "description": "",
   "main": "build/agent.js",
   "output": "agent.blob",

--- a/src/api/device.info.ts
+++ b/src/api/device.info.ts
@@ -1,7 +1,6 @@
-import getDeviceInfo from "../utils/os.informations";
-import axios, {AxiosError} from "axios";
+import axios from 'axios';
 import { URL_MASTER } from '../config';
-import logger from "../logger";
+import logger from '../logger';
 
 const sendDeviceInfoToApi = async (hostId: string, deviceInfo: any) => {
     logger.info(`[AGENT] sendDeviceInfoToApi - To -> ${URL_MASTER}/api/devices/${hostId}`);

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -61,6 +61,7 @@ declare namespace ServerAPI {
 
   type DeviceInfo = {
     id: string;
+    logPath: string;
     os?: OSInfo;
     ip?: string;
     uptime?: number;

--- a/src/utils/os.informations.ts
+++ b/src/utils/os.informations.ts
@@ -1,11 +1,11 @@
-import si from 'systeminformation';
 import osu from 'node-os-utils';
+import si from 'systeminformation';
+import { version } from '../../package.json';
 import { OVERRIDE_IP_DETECTION } from '../config';
-import logger from "../logger";
-import {version} from '../../package.json';
+import logger, { LOG_DIRECTORY } from '../logger';
 
 export default async function getDeviceInfo(hostId : string) {
-  let deviceInfo: ServerAPI.DeviceInfo = {id : hostId, agentVersion: version};
+  let deviceInfo: ServerAPI.DeviceInfo = {id : hostId, agentVersion: version, logPath: LOG_DIRECTORY};
 
   const valueObject = {
     cpu: '*',


### PR DESCRIPTION
Bumped the package version from 0.1.3 to 0.1.7. Integrated `logPath` and `agentLogPath` attributes in device-related modules, ensuring consistency between the server, shared library, and typings. Also cleaned up unused imports in `src/api/device.info.ts`.