### PR TITLE
Add environment variable API_URL_MASTER to agent service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     image: ghcr.io/squirrelcorporation/squirrelserversmanager-agent:docker
     network_mode: host
     privileged: true
+    environment:
+      - API_URL_MASTER=${API_URL_MASTER}
     pid: host
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
Include API_URL_MASTER environment variable to configure the master API URL in the agent service. This ensures the agent can dynamically adapt to different API endpoints based on configuration.