### PR TITLE
Change config import path in logger.ts

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,5 @@
-import { LOGS_PATH } from '@/config';
 import winston from 'winston';
+import { LOGS_PATH } from './config';
 import 'winston-daily-rotate-file';
 
 


### PR DESCRIPTION
Updated the import path for LOGS_PATH from '@/config' to './config' to ensure correct module resolution. This fix addresses issues with path resolution in certain build environments.