### PR TITLE
Log response headers on device info API errors

### DIFF
--- a/src/api/device.info.ts
+++ b/src/api/device.info.ts
@@ -2,6 +2,13 @@ import axios from 'axios';
 import { URL_MASTER } from '../config';
 import logger from '../logger';
 
+const logHeaders = (headers: any) => {
+    logger.debug('[AGENT] sendDeviceInfoToApi - Response Headers:');
+    for (const [key, value] of Object.entries(headers)) {
+        logger.debug(`Header:   ${key}: ${value}`);
+    }
+};
+
 const sendDeviceInfoToApi = async (hostId: string, deviceInfo: any) => {
     logger.info(`[AGENT] sendDeviceInfoToApi - To -> ${URL_MASTER}/api/devices/${hostId}`);
 
@@ -13,6 +20,7 @@ const sendDeviceInfoToApi = async (hostId: string, deviceInfo: any) => {
       .catch((error) => {
           logger.error(error.message);
           logger.debug(error);
+          logHeaders(error.response.headers);
           if (error?.response?.status === 404) {
               throw new Error(`[AGENT] sendDeviceInfoToApi - Trying to send device info without registering first try to delete the hostid.txt file first`);
           }


### PR DESCRIPTION
This commit adds a new function to log the response headers when an error occurs in the `sendDeviceInfoToApi` method. This will assist in debugging by providing more context about the API response during failure scenarios.